### PR TITLE
Fix i18n generation and crash when game name filter used for games without names.

### DIFF
--- a/src/Depressurizer/AutoCats/AutoCatName.cs
+++ b/src/Depressurizer/AutoCats/AutoCatName.cs
@@ -95,6 +95,12 @@ namespace Depressurizer.AutoCats
                 return AutoCatResult.NotInDatabase;
             }
 
+            if (string.IsNullOrEmpty(game?.Name))
+            {
+                Logger.Error(GlobalStrings.Log_AutoCat_GameNameNullOrEmpty);
+                return AutoCatResult.Failure;
+            }
+
             string cat = game.Name.Substring(0, 1);
             cat = cat.ToUpper();
             if (SkipThe && cat == "T" && game.Name.Substring(0, 4).ToUpper() == "THE ")

--- a/src/Depressurizer/Depressurizer.csproj
+++ b/src/Depressurizer/Depressurizer.csproj
@@ -111,6 +111,11 @@
     <Compile Update="AutoCats\AutoCatConfigPanel_Year.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Update="GlobalStrings.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GlobalStrings.resx</DependentUpon>
+    </Compile>
     <Compile Update="Lib\ExtListView.cs">
       <SubType>Component</SubType>
     </Compile>
@@ -187,5 +192,11 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Depressurizer.Core\Depressurizer.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="GlobalStrings.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GlobalStrings.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/src/Depressurizer/GlobalStrings.Designer.cs
+++ b/src/Depressurizer/GlobalStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Depressurizer {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GlobalStrings {
@@ -922,7 +922,7 @@ namespace Depressurizer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occured while updating from howlongtobeatsteam.com: {0}.
+        ///   Looks up a localized string similar to An error occured while updating from github.com/julianxhokaxhiu/hltb-scraper: {0}.
         /// </summary>
         internal static string DBEditDlg_ErrorWhileUpdatingHltb {
             get {
@@ -1382,7 +1382,7 @@ namespace Depressurizer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Whether to use imputed (statistically probable) times from howlongtobeatsteam.com for missing times. .
+        ///   Looks up a localized string similar to Whether to use imputed (statistically probable) times from github.com/julianxhokaxhiu/hltb-scraper for missing times. .
         /// </summary>
         internal static string DlgOptions_Help_IncludeImputedTimes {
             get {
@@ -2071,6 +2071,15 @@ namespace Depressurizer {
         internal static string Log_AutoCat_GamelistNull {
             get {
                 return ResourceManager.GetString("Log_AutoCat_GamelistNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to Autocategorize game because gamename was null or empty..
+        /// </summary>
+        internal static string Log_AutoCat_GameNameNullOrEmpty {
+            get {
+                return ResourceManager.GetString("Log_AutoCat_GameNameNullOrEmpty", resourceCulture);
             }
         }
         
@@ -3450,6 +3459,16 @@ namespace Depressurizer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Detected Steam running.
+        ///Please close it to prevent further DB corruption before using Depressurizer..
+        /// </summary>
+        internal static string TextSteam_AlreayRunning {
+            get {
+                return ResourceManager.GetString("TextSteam_AlreayRunning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Node is a value, not an array. Cannot get key {0}.
         /// </summary>
         internal static string TextVdfFile_CanNotGetKey {
@@ -3491,17 +3510,6 @@ namespace Depressurizer {
         internal static string TextVdfFile_UnexpectedEOF {
             get {
                 return ResourceManager.GetString("TextVdfFile_UnexpectedEOF", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Unexpected end-of-file reached: Unterminated string..
-        /// </summary>
-        internal static string TextSteam_AlreayRunning
-        {
-            get
-            {
-                return ResourceManager.GetString("TextSteam_AlreayRunning", resourceCulture);
             }
         }
     }

--- a/src/Depressurizer/GlobalStrings.resx
+++ b/src/Depressurizer/GlobalStrings.resx
@@ -1312,4 +1312,7 @@ This could take up to a few seconds per game.</value>
     <value>Detected Steam running.
 Please close it to prevent further DB corruption before using Depressurizer.</value>
   </data>
+  <data name="Log_AutoCat_GameNameNullOrEmpty" xml:space="preserve">
+    <value>Failed to Autocategorize game because gamename was null or empty.</value>
+  </data>
 </root>

--- a/src/Depressurizer/GlobalStrings.zh-CN.resx
+++ b/src/Depressurizer/GlobalStrings.zh-CN.resx
@@ -1307,4 +1307,7 @@ See: http://www.evanmiller.org/how-not-to-sort-by-average-rating.html</value>
   <data name="TextSteam_AlreayRunning" xml:space="preserve">
     <value />
   </data>
+  <data name="Log_AutoCat_GameNameNullOrEmpty" xml:space="preserve">
+    <value />
+  </data>
 </root>


### PR DESCRIPTION
Resolves #14
- Depressurizer crashes when a game has no name and the filter for adding categories by the first letter of the game name is configured.
  - EDIT AUTOCATS -> Create -> Type: Name

Resolves GlobalStrings.resx

- Auto file generation for GlobalStrings.Designer.cs not working.