### PR TITLE
fix auto remove empty categories

### DIFF
--- a/src/Depressurizer.Core/Models/GameList.cs
+++ b/src/Depressurizer.Core/Models/GameList.cs
@@ -808,8 +808,6 @@ namespace Depressurizer.Core.Models
                         Games.Remove(g);
                     }
 
-                    RemoveEmptyCategories();
-
                     // Load launch IDs
                     LoadShortcutLaunchIds(steamId, out StringDictionary launchIds);
 

--- a/src/Depressurizer/MainForm.cs
+++ b/src/Depressurizer/MainForm.cs
@@ -3245,7 +3245,6 @@ namespace Depressurizer
 
                     //RunAutoCats(currentProfile.AutoCats);  WILL THIS WORK?  ARE AUTOCATS SELECTED VALUES SET CORRECTLY
                     RunAutoCats(autoCats, true);
-                    RemoveEmptyCats();
                     FilterGameList(true);
                 }
             }


### PR DESCRIPTION
Remove the automatic to remove empty categories #22

- When auto-categorizing
- When importing steam shortcuts 

User still can manually trigger the removal of empty categories.

- Tools -> Remove Empty Categories