### PR TITLE
set scrape date when store site is not avariable or not accessible

### DIFF
--- a/src/Depressurizer.Core/Models/DatabaseEntry.cs
+++ b/src/Depressurizer.Core/Models/DatabaseEntry.cs
@@ -725,6 +725,7 @@ namespace Depressurizer.Core.Models
                     if (Regexes.IsSteamStore.IsMatch(resp.Headers[HttpResponseHeader.Location]))
                     {
                         Logger.Warn("Scraping {0}: Location header points to the Steam Store homepage, aborting scraping.", AppId);
+                        LastStoreScrape = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                         return AppType.Unknown;
                     }
 
@@ -776,7 +777,8 @@ namespace Depressurizer.Core.Models
                 }
                 else if (resp.ResponseUri.Segments[1] != "app/")
                 {
-                    Logger.Warn("Scraping {0}: Redirected to a non-app URL, aborting scraping.", AppId);
+                    Logger.Warn("Scraping {0}: Redirected to a non-app URL ({1}), aborting scraping.", AppId, resp.ResponseUri.Segments[1]);
+                    LastStoreScrape = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                     return AppType.Unknown;
                 }
                 // The URI ends with "/app/" ?


### PR DESCRIPTION
In some cases the scrape date is not set in the database #35 
- store page not exists (removed games, some tools)
- store page is not accessible (adult games)