### PR TITLE
fix hidden games are sorted in cats

### DIFF
--- a/src/Depressurizer.Core/Models/GameInfo.cs
+++ b/src/Depressurizer.Core/Models/GameInfo.cs
@@ -193,7 +193,7 @@ namespace Depressurizer.Core.Models
                 return;
             }
 
-            if (Categories.Add(category) && !IsHidden)
+            if (Categories.Add(category))
             {
                 category.Count++;
             }
@@ -239,11 +239,6 @@ namespace Depressurizer.Core.Models
 
             foreach (Category category in Categories)
             {
-                if (IsHidden)
-                {
-                    continue;
-                }
-
                 category.Count--;
             }
 

--- a/src/Depressurizer/MainForm.cs
+++ b/src/Depressurizer/MainForm.cs
@@ -1579,32 +1579,21 @@ namespace Depressurizer
             foreach (GameInfo g in CurrentProfile.GameData.Games.Values)
             {
                 if (g.Id < 0 && !CurrentProfile.IncludeShortcuts)
-                {
                     continue;
-                }
 
                 if (g.IsHidden)
-                {
                     hidden++;
-                    continue;
-                }
 
                 all++;
 
                 if (!g.HasCategories())
-                {
                     uncategorized++;
-                }
 
                 if (g.Id <= 0 || !Database.Contains(g.Id, out DatabaseEntry entry))
-                {
                     continue;
-                }
 
                 if (Database.SupportsVR(g.Id))
-                {
                     vr++;
-                }
 
                 switch (entry.AppType)
                 {
@@ -4345,16 +4334,12 @@ namespace Depressurizer
         private bool ShouldDisplayGame(GameInfo gameInfo)
         {
             if (CurrentProfile == null || gameInfo == null)
-            {
                 return false;
-            }
 
             if (_currentFilterRegex != null)
             {
                 if (!_currentFilterRegex.IsMatch(gameInfo.Name))
-                {
                     return false;
-                }
             }
             else if (!string.IsNullOrWhiteSpace(mtxtSearch.Text) && gameInfo.Name.IndexOf(mtxtSearch.Text, StringComparison.CurrentCultureIgnoreCase) == -1)
             {
@@ -4362,80 +4347,55 @@ namespace Depressurizer
             }
 
             if (gameInfo.Id < 0 && !CurrentProfile.IncludeShortcuts)
-            {
                 return false;
-            }
 
             if (!CurrentProfile.GameData.Games.ContainsKey(gameInfo.Id))
-            {
                 return false;
-            }
 
             var selectedItems = lstCategories.SelectedItems;
             if (selectedItems.Count == 0)
-            {
                 return false;
-            }
+
             var selectedItemsTag = lstCategories.SelectedItems[0].Tag;
 
             if (AdvancedCategoryFilter)
-            {
                 return gameInfo.IncludeGame(_advFilter);
-            }
 
-            if (gameInfo.IsHidden)
-            {
-                return selectedItemsTag.ToString() == Resources.SpecialCategoryHidden;
-            }
+            if (gameInfo.IsHidden && selectedItemsTag.ToString() == Resources.SpecialCategoryHidden)
+                return true;
 
             // <All>
             if (selectedItemsTag.ToString() == Resources.SpecialCategoryAll)
-            {
                 return true;
-            }
 
             // <Uncategorized>
             if (selectedItemsTag.ToString() == Resources.SpecialCategoryUncategorized)
-            {
                 return gameInfo.Categories.Count == 0;
-            }
 
             bool inDatabase = Database.Contains(gameInfo.Id, out DatabaseEntry entry);
 
             // <Games>
             if (selectedItemsTag.ToString() == Resources.SpecialCategoryGames)
-            {
                 return inDatabase && entry.AppType == AppType.Game;
-            }
 
             // <Mods>
             if (selectedItemsTag.ToString() == Resources.SpecialCategoryMods)
-            {
                 return inDatabase && entry.AppType == AppType.Mod;
-            }
 
             // <Software>
             if (selectedItemsTag.ToString() == Resources.SpecialCategorySoftware)
-            {
                 return inDatabase && entry.AppType == AppType.Application;
-            }
 
             // <VR>
             if (selectedItemsTag.ToString() == Resources.SpecialCategoryVR)
-            {
                 return inDatabase && Database.SupportsVR(gameInfo.Id);
-            }
 
             if (!(selectedItemsTag is Category category))
-            {
                 return false;
-            }
 
             // <Favorite>
             if (category.Name == Resources.SpecialCategoryFavorite)
-            {
                 return gameInfo.IsFavorite();
-            }
 
             return gameInfo.ContainsCategory(category);
         }


### PR DESCRIPTION
Fix Depressurizer shows empty categories when they include only hidden games (issue #53)

Steam changed its behavior: previously, hidden games could not be assigned to categories. Now, when you unhide a game in Steam, its categories are restored.

Changes:
- Hidden games are now visible in Depressurizer categories.
