### PR TITLE
Add null handling for the database search box

### DIFF
--- a/src/Depressurizer/DBEdit/DBEditDlg.cs
+++ b/src/Depressurizer/DBEdit/DBEditDlg.cs
@@ -974,9 +974,12 @@ namespace Depressurizer
                 }
             }
 
-            if (_currentFilter.Length > 0 && entry.Name.IndexOf(_currentFilter, StringComparison.CurrentCultureIgnoreCase) == -1)
+            if (!string.IsNullOrEmpty(_currentFilter))
             {
-                return false;
+                if (string.IsNullOrEmpty(entry.Name) || entry.Name.IndexOf(_currentFilter, StringComparison.CurrentCultureIgnoreCase) == -1)
+                {
+                    return false;
+                }
             }
 
             return true;


### PR DESCRIPTION
Added handling for null strings in the database editor's text search field to prevent crashing Depressurizer when text is entered.